### PR TITLE
[FEAT] 로그아웃 구현

### DIFF
--- a/DOTCHI/DOTCHI/Global/Bases/BaseViewController.swift
+++ b/DOTCHI/DOTCHI/Global/Bases/BaseViewController.swift
@@ -123,6 +123,14 @@ class BaseViewController: UIViewController, UIGestureRecognizerDelegate {
         keychainManager.set(newPassword, forKey: KeychainKeys.password.rawValue)
     }
     
+    /// 로그아웃 시 모든 Keychain 데이터 삭제
+    func clearKeychainData() {
+        self.keychainManager.delete(KeychainKeys.accessToken.rawValue)
+        self.keychainManager.delete(KeychainKeys.refreshToken.rawValue)
+        self.keychainManager.delete(KeychainKeys.username.rawValue)
+        self.keychainManager.delete(KeychainKeys.password.rawValue)
+    }
+    
     /// 신고 사유 선택 action sheet
 //    func reportActionSheet(userId: Int) -> UIAlertController {
 //        let reportActionSheet: UIAlertController = UIAlertController(

--- a/DOTCHI/DOTCHI/Networks/Routers/AuthRouter.swift
+++ b/DOTCHI/DOTCHI/Networks/Routers/AuthRouter.swift
@@ -8,9 +8,9 @@
 import Foundation
 import Moya
 
-
 enum AuthRouter {
     case requestSignin(data: SigninRequestDTO)
+    case logout
 }
 
 extension AuthRouter: TargetType {
@@ -23,6 +23,8 @@ extension AuthRouter: TargetType {
         switch self {
         case .requestSignin:
             return "/user/login"
+        case .logout:
+            return "/user/logout"
         }
     }
 
@@ -30,6 +32,8 @@ extension AuthRouter: TargetType {
         switch self {
         case .requestSignin:
             return .post
+        case .logout:
+            return .get
         }
     }
 
@@ -37,11 +41,18 @@ extension AuthRouter: TargetType {
         switch self {
         case .requestSignin(let data):
             return .requestJSONEncodable(data)
+        case .logout:
+            return .requestPlain
         }
     }
 
     var headers: [String: String]? {
         switch self {
+        case .logout:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(UserInfo.shared.accessToken)",
+            ]
         default:
             return ["Content-Type": "application/json"]
         }

--- a/DOTCHI/DOTCHI/Networks/Services/AuthService.swift
+++ b/DOTCHI/DOTCHI/Networks/Services/AuthService.swift
@@ -36,4 +36,20 @@ extension AuthService: AuthServiceProtocol {
             }
         }
     }
+    
+    // [GET] 로그아웃
+    
+    func logout(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.logout) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, String.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }   
 }

--- a/DOTCHI/DOTCHI/Sources/Screens/My/SettingViewController.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/SettingViewController.swift
@@ -11,6 +11,8 @@ import MessageUI
 
 class SettingViewController: BaseViewController {
     private let userService = UserService.shared
+    private let authService = AuthService.shared
+    
     private let scrollView = UIScrollView()
     private let contentView = UIView()
     private let profileImageView = UIImageView()
@@ -331,7 +333,26 @@ class SettingViewController: BaseViewController {
     }
     
     @objc private func logout() {
-        
+        authService.logout { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success:
+                self.clearKeychainData()
+                
+                DispatchQueue.main.async {
+                    let loginVC = SigninViewController()
+                    let navController = UINavigationController(rootViewController: loginVC)
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let window = windowScene.windows.first {
+                        window.rootViewController = navController
+                        window.makeKeyAndVisible()
+                    }
+                }
+            default:
+                self.showNetworkErrorAlert()
+            }
+        }
     }
     
     @objc private func deleteAccount() {


### PR DESCRIPTION
## 작업한 내용
- 로그아웃 구현

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 로그아웃 하고 바로 나오는 로그인 화면이랑, 앱을 껐다 재실행 시켰을 때 나오는 로그인 화면(키체인에 저장된 데이터가 없어 자동 로그인이 되지 않았을 때)이 다른 것 같아 보입니다! 
- -> (24″) 스크롤이 돼서 Splash 뷰가 보이는데 의도한건지 궁금해서요. 만약 그렇다면 제가 로그아웃 버튼을 눌렀을 때 SigninViewController 띄우는 방법을 변경해야 할 것 같아서요.

## 📸 스크린샷
https://github.com/user-attachments/assets/84ea0d41-8f94-40af-8d64-05a845c90891

## 관련 이슈
- Resolved: #22 
